### PR TITLE
fixes invalid syntax in example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ slackMessages.action('welcome_button', (payload) => {
   // Note that the payload contains a copy of the original message (`payload.original_message`).
   const replacement = payload.original_message;
   // Typically, you want to acknowledge the action and remove the interactive elements from the message
-  const replacement.text =`Welcome ${payload.user.name}`;
+  replacement.text =`Welcome ${payload.user.name}`;
   delete replacement.attachments[0].actions;
   return replacement;
 });


### PR DESCRIPTION
see title

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing guidelines](https://github.com/slackapi/node-slack-interactive-messages/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
