### PR TITLE
WIP: Fix menuoptions requests

### DIFF
--- a/src/express-middleware.js
+++ b/src/express-middleware.js
@@ -19,7 +19,9 @@ export function createExpressMiddleware(adapter) {
       return contentReady.then((c) => {
         res.status(status);
         res.set('X-Slack-Powered-By', poweredBy);
-        if (c) {
+        if (typeof c === 'string') {
+          res.send(c);
+        } else if (c) {
           res.json(c);
         } else {
           res.end();

--- a/src/util.js
+++ b/src/util.js
@@ -3,12 +3,18 @@ import pkg from '../package.json';
 
 function escape(s) { return s.replace('/', ':').replace(' ', '_'); }
 
+export const errorCodes = {
+  PROMISE_TIMEOUT: 'SLACKMESSAGEMIDDLEWARE_PROMISE_TIMEOUT',
+};
+
 export function promiseTimeout(ms, promise) {
   // Create a promise that rejects in <ms> milliseconds
   const timeout = new Promise((resolve, reject) => {
     const id = setTimeout(() => {
       clearTimeout(id);
-      reject('Promise timed out');
+      const error = new Error('Promise timed out');
+      error.code = errorCodes.PROMISE_TIMEOUT;
+      reject(error);
     }, ms);
   });
   // Returns a race between our timeout and the passed in promise


### PR DESCRIPTION
###  Summary

fixes #23 
fixes #25 

this impacts the table in #27 by making it look like the following:

**Type of Request**|**`cb(): Message`**|**`cb(): Promise<Message>`**|**`respond(m: Message)`**|**`respond(m: Promise<Message>)`**|**Notes**
:-----:|:-----:|:-----:|:-----:|:-----:|:-----:
Message Action (Button, Select) incl. embeded in App Unfurl|synchronous response| if resolved under timeout, synchronous response; else `response_url` request |`response_url` request (can be used several times)|error: axios will likely throw| 
Dialog Submission|synchronous response|synchronous response|`response_url` request (can be used several times) - not a replacement, used as follow up|error: axios will likely throw | A warning is logged if the synchronous response takes longer than the timeout
Menu Options|synchronous response|synchronous response| - | - | A warning is logged if the synchronous response takes longer than the timeout

TODO:
- [ ] tests
- [ ] creating config variable for timeout
- [ ] better error message when calling `respond()` with a Promise (maybe)

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing guidelines](https://github.com/slackapi/node-slack-interactive-messages/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
