### PR TITLE
Async dispatch

### DIFF
--- a/test/unit/test-adapter.js
+++ b/test/unit/test-adapter.js
@@ -423,7 +423,7 @@ describe('SlackMessageAdapter', function () {
         });
         dispatchResponse = this.adapter.dispatch(requestPayload);
         return Promise.all([
-          assertResponseStatusAndMessage(dispatchResponse, 200, ''),
+          assertResponseStatusAndMessage(dispatchResponse, 200),
           expectedAsyncRequest
         ]);
       });
@@ -437,7 +437,7 @@ describe('SlackMessageAdapter', function () {
           return delayed(timeout * 1.1, undefined, 'test error');
         });
         dispatchResponse = this.adapter.dispatch(requestPayload);
-        return assertResponseStatusAndMessage(dispatchResponse, 200, '');
+        return assertResponseStatusAndMessage(dispatchResponse, 200);
       });
       it('should handle the callback returning a promise that fails before the timeout with a ' +
          'sychronous response', function () {
@@ -470,7 +470,7 @@ describe('SlackMessageAdapter', function () {
         });
         dispatchResponse = this.adapter.dispatch(requestPayload);
         return Promise.all([
-          assertResponseStatusAndMessage(dispatchResponse, 200, ''),
+          assertResponseStatusAndMessage(dispatchResponse, 200),
           expectedAsyncRequest
         ]);
       });
@@ -497,7 +497,7 @@ describe('SlackMessageAdapter', function () {
         });
         dispatchResponse = this.adapter.dispatch(requestPayload);
         return Promise.all([
-          assertResponseStatusAndMessage(dispatchResponse, 200, ''),
+          assertResponseStatusAndMessage(dispatchResponse, 200),
           expectedAsyncRequest
         ]);
       });
@@ -527,7 +527,7 @@ describe('SlackMessageAdapter', function () {
         });
         dispatchResponse = this.adapter.dispatch(requestPayload);
         return Promise.all([
-          assertResponseStatusAndMessage(dispatchResponse, 200, ''),
+          assertResponseStatusAndMessage(dispatchResponse, 200),
           expectedAsyncRequest
         ]);
       });
@@ -641,7 +641,7 @@ describe('SlackMessageAdapter', function () {
           assert.isFunction(respond);
         });
         dispatchResponse = this.adapter.dispatch(requestPayload);
-        return assertResponseStatusAndMessage(dispatchResponse, 200, '');
+        return assertResponseStatusAndMessage(dispatchResponse, 200);
       });
 
       it('should handle the callback using respond to send a follow up message', function () {
@@ -663,7 +663,7 @@ describe('SlackMessageAdapter', function () {
         });
         dispatchResponse = this.adapter.dispatch(requestPayload);
         return Promise.all([
-          assertResponseStatusAndMessage(dispatchResponse, 200, ''),
+          assertResponseStatusAndMessage(dispatchResponse, 200),
           expectedAsyncRequest
         ]);
       });
@@ -739,7 +739,7 @@ describe('SlackMessageAdapter', function () {
           assert.isUndefined(secondArg);
         });
         dispatchResponse = this.adapter.dispatch(requestPayload);
-        return assertResponseStatusAndMessage(dispatchResponse, 200, '');
+        return assertResponseStatusAndMessage(dispatchResponse, 200);
       });
     });
 

--- a/test/unit/test-adapter.js
+++ b/test/unit/test-adapter.js
@@ -311,15 +311,16 @@ describe('SlackMessageAdapter', function () {
 
     /**
      * Assert the result of a dispatch contains a certain message
-     * @param {Object} response actual return value of adapter.dispatch (synchronous reponse)
-     * @param {Object|string|undefined} message expected value of response body
+     * @param {Promise<object>} response actual return value of adapter.dispatch
+     * @param {number} status expected status
+     * @param {Object|string|undefined} content expected value of response body
      * @returns {Promise<void>}
      */
-    function assertResponseContainsMessage(response, message) {
-      return Promise.resolve(response.content)
-        .then(function (content) {
-          assert.deepEqual(content, message);
-        });
+    function assertResponseStatusAndMessage(response, status, content) {
+      return response.then(function (res) {
+        assert.equal(status, res.status);
+        assert.deepEqual(content, res.content);
+      });
     }
 
     /**
@@ -386,8 +387,7 @@ describe('SlackMessageAdapter', function () {
           return replacement;
         });
         dispatchResponse = this.adapter.dispatch(requestPayload);
-        assert.equal(dispatchResponse.status, 200);
-        return assertResponseContainsMessage(dispatchResponse, replacement);
+        return assertResponseStatusAndMessage(dispatchResponse, 200, replacement);
       });
       it('should handle the callback returning a promise of a message before the timeout with a ' +
          'synchronous response', function () {
@@ -402,8 +402,7 @@ describe('SlackMessageAdapter', function () {
           return delayed(timeout * 0.1, replacement);
         });
         dispatchResponse = this.adapter.dispatch(requestPayload);
-        assert.equal(dispatchResponse.status, 200);
-        return assertResponseContainsMessage(dispatchResponse, replacement);
+        return assertResponseStatusAndMessage(dispatchResponse, 200, replacement);
       });
       it('should handle the callback returning a promise of a message after the timeout with an ' +
          'asynchronous response', function () {
@@ -423,13 +422,13 @@ describe('SlackMessageAdapter', function () {
           return delayed(timeout * 1.1, replacement);
         });
         dispatchResponse = this.adapter.dispatch(requestPayload);
-        assert.equal(dispatchResponse.status, 200);
         return Promise.all([
-          assertResponseContainsMessage(dispatchResponse, ''),
+          assertResponseStatusAndMessage(dispatchResponse, 200, ''),
           expectedAsyncRequest
         ]);
       });
-      it('should handle the callback returning a promise that fails after the timeout with a sychronous response', function () {
+      it('should handle the callback returning a promise that fails after the timeout with a ' +
+         'sychronous response', function () {
         var dispatchResponse;
         var requestPayload = this.requestPayload;
         var timeout = this.adapter.syncResponseTimeout;
@@ -438,10 +437,10 @@ describe('SlackMessageAdapter', function () {
           return delayed(timeout * 1.1, undefined, 'test error');
         });
         dispatchResponse = this.adapter.dispatch(requestPayload);
-        assert.equal(dispatchResponse.status, 200);
-        return assertResponseContainsMessage(dispatchResponse, '');
+        return assertResponseStatusAndMessage(dispatchResponse, 200, '');
       });
-      it('should handle the callback returning a promise that fails before the timeout with a sychronous response', function () {
+      it('should handle the callback returning a promise that fails before the timeout with a ' +
+         'sychronous response', function () {
         var dispatchResponse;
         var requestPayload = this.requestPayload;
         var timeout = this.adapter.syncResponseTimeout;
@@ -450,8 +449,7 @@ describe('SlackMessageAdapter', function () {
           return delayed(timeout * 0.1, undefined, 'test error');
         });
         dispatchResponse = this.adapter.dispatch(requestPayload);
-        assert.equal(dispatchResponse.status, 200);
-        return assertResponseContainsMessage(dispatchResponse, 'An error occurred. Please report this to the app developer.');
+        return assertResponseStatusAndMessage(dispatchResponse, 500);
       });
       it('should handle the callback returning nothing and using respond to send a message', function () {
         var dispatchResponse;
@@ -471,9 +469,8 @@ describe('SlackMessageAdapter', function () {
             });
         });
         dispatchResponse = this.adapter.dispatch(requestPayload);
-        assert.equal(dispatchResponse.status, 200);
         return Promise.all([
-          assertResponseContainsMessage(dispatchResponse, ''),
+          assertResponseStatusAndMessage(dispatchResponse, 200, ''),
           expectedAsyncRequest
         ]);
       });
@@ -499,9 +496,8 @@ describe('SlackMessageAdapter', function () {
           return delayed(timeout * 1.1, firstReplacement);
         });
         dispatchResponse = this.adapter.dispatch(requestPayload);
-        assert.equal(dispatchResponse.status, 200);
         return Promise.all([
-          assertResponseContainsMessage(dispatchResponse, ''),
+          assertResponseStatusAndMessage(dispatchResponse, 200, ''),
           expectedAsyncRequest
         ]);
       });
@@ -530,9 +526,8 @@ describe('SlackMessageAdapter', function () {
             });
         });
         dispatchResponse = this.adapter.dispatch(requestPayload);
-        assert.equal(dispatchResponse.status, 200);
         return Promise.all([
-          assertResponseContainsMessage(dispatchResponse, ''),
+          assertResponseStatusAndMessage(dispatchResponse, 200, ''),
           expectedAsyncRequest
         ]);
       });
@@ -556,8 +551,7 @@ describe('SlackMessageAdapter', function () {
             return delayed(timeout * 1.1, replacement);
           });
           dispatchResponse = this.adapter.dispatch(requestPayload);
-          assert.equal(dispatchResponse.status, 200);
-          return assertResponseContainsMessage(dispatchResponse, replacement);
+          return assertResponseStatusAndMessage(dispatchResponse, 200, replacement);
         });
         it('should handle the callback returning a promise that fails after the timeout with a ' +
            'sychronous response', function () {
@@ -569,12 +563,7 @@ describe('SlackMessageAdapter', function () {
             return delayed(timeout * 1.1, undefined, 'test error');
           });
           dispatchResponse = this.adapter.dispatch(requestPayload);
-          assert.equal(dispatchResponse.status, 200);
-          return Promise.resolve(dispatchResponse.content).then(function () {
-            throw new Error('should not resolve');
-          }, function (error) {
-            assert.equal(error.message, 'test error');
-          });
+          return assertResponseStatusAndMessage(dispatchResponse, 500);
         });
       });
     });
@@ -609,8 +598,7 @@ describe('SlackMessageAdapter', function () {
           return submissionResponse;
         });
         dispatchResponse = this.adapter.dispatch(requestPayload);
-        assert.equal(dispatchResponse.status, 200);
-        return assertResponseContainsMessage(dispatchResponse, submissionResponse);
+        return assertResponseStatusAndMessage(dispatchResponse, 200, submissionResponse);
       });
 
       it('should handle the callback returning a promise of a message before the timeout with a ' +
@@ -626,8 +614,7 @@ describe('SlackMessageAdapter', function () {
           return delayed(timeout * 0.1, submissionResponse);
         });
         dispatchResponse = this.adapter.dispatch(requestPayload);
-        assert.equal(dispatchResponse.status, 200);
-        return assertResponseContainsMessage(dispatchResponse, submissionResponse);
+        return assertResponseStatusAndMessage(dispatchResponse, 200, submissionResponse);
       });
 
       it('should handle the callback returning a promise of a message after the timeout with a ' +
@@ -643,8 +630,7 @@ describe('SlackMessageAdapter', function () {
           return delayed(timeout * 1.1, submissionResponse);
         });
         dispatchResponse = this.adapter.dispatch(requestPayload);
-        assert.equal(dispatchResponse.status, 200);
-        return assertResponseContainsMessage(dispatchResponse, submissionResponse);
+        return assertResponseStatusAndMessage(dispatchResponse, 200, submissionResponse);
       });
 
       it('should handle the callback returning nothing with a synchronous response', function () {
@@ -655,8 +641,7 @@ describe('SlackMessageAdapter', function () {
           assert.isFunction(respond);
         });
         dispatchResponse = this.adapter.dispatch(requestPayload);
-        assert.equal(dispatchResponse.status, 200);
-        return assertResponseContainsMessage(dispatchResponse, '');
+        return assertResponseStatusAndMessage(dispatchResponse, 200, '');
       });
 
       it('should handle the callback using respond to send a follow up message', function () {
@@ -677,9 +662,8 @@ describe('SlackMessageAdapter', function () {
             });
         });
         dispatchResponse = this.adapter.dispatch(requestPayload);
-        assert.equal(dispatchResponse.status, 200);
         return Promise.all([
-          assertResponseContainsMessage(dispatchResponse, ''),
+          assertResponseStatusAndMessage(dispatchResponse, 200, ''),
           expectedAsyncRequest
         ]);
       });
@@ -712,8 +696,7 @@ describe('SlackMessageAdapter', function () {
           return optionsResponse;
         });
         dispatchResponse = this.adapter.dispatch(requestPayload);
-        assert.equal(dispatchResponse.status, 200);
-        return assertResponseContainsMessage(dispatchResponse, optionsResponse);
+        return assertResponseStatusAndMessage(dispatchResponse, 200, optionsResponse);
       });
 
       it('should handle the callback returning a promise of options before the timeout with a ' +
@@ -729,8 +712,7 @@ describe('SlackMessageAdapter', function () {
           return delayed(timeout * 0.1, optionsResponse);
         });
         dispatchResponse = this.adapter.dispatch(requestPayload);
-        assert.equal(dispatchResponse.status, 200);
-        return assertResponseContainsMessage(dispatchResponse, optionsResponse);
+        return assertResponseStatusAndMessage(dispatchResponse, 200, optionsResponse);
       });
 
       it('should handle the callback returning a promise of options after the timeout with a ' +
@@ -746,8 +728,7 @@ describe('SlackMessageAdapter', function () {
           return delayed(timeout * 1.1, optionsResponse);
         });
         dispatchResponse = this.adapter.dispatch(requestPayload);
-        assert.equal(dispatchResponse.status, 200);
-        return assertResponseContainsMessage(dispatchResponse, optionsResponse);
+        return assertResponseStatusAndMessage(dispatchResponse, 200, optionsResponse);
       });
 
       it('should handle the callback returning nothing with a synchronous response', function () {
@@ -758,17 +739,14 @@ describe('SlackMessageAdapter', function () {
           assert.isUndefined(secondArg);
         });
         dispatchResponse = this.adapter.dispatch(requestPayload);
-        assert.equal(dispatchResponse.status, 200);
-        return assertResponseContainsMessage(dispatchResponse, '');
+        return assertResponseStatusAndMessage(dispatchResponse, 200, '');
       });
     });
 
     describe('callback matching', function () {
-      // TODO: is this really the behavior we want?
-      it('should return a blank success when there are no callbacks registered', function () {
+      it('should return undefined when there are no callbacks registered', function () {
         var response = this.adapter.dispatch({});
-        assert.equal(response.status, 200);
-        return assertResponseContainsMessage(response, '');
+        assert.isUndefined(response);
       });
 
       describe('callback ID based matching', function () {
@@ -777,22 +755,20 @@ describe('SlackMessageAdapter', function () {
           this.callback = sinon.spy();
         });
 
-        it('should return a blank success with a string mismatch', function () {
+        it('should return undefined with a string mismatch', function () {
           var response;
           this.adapter.action('b', this.callback);
           response = this.adapter.dispatch(this.payload);
           assert(this.callback.notCalled);
-          assert.equal(response.status, 200);
-          return assertResponseContainsMessage(response, '');
+          assert.isUndefined(response);
         });
 
-        it('should return a blank success with a regexp mismatch', function () {
+        it('should return undefined with a RegExp mismatch', function () {
           var response;
           this.adapter.action(/b/, this.callback);
           response = this.adapter.dispatch(this.payload);
           assert(this.callback.notCalled);
-          assert.equal(response.status, 200);
-          return assertResponseContainsMessage(response, '');
+          assert.isUndefined(response);
         });
       });
 
@@ -802,13 +778,12 @@ describe('SlackMessageAdapter', function () {
           this.callback = sinon.spy();
         });
 
-        it('should return a blank success with type is present in constraints and it mismatches', function () {
+        it('should return undefined when type is present in constraints and it mismatches', function () {
           var response;
           this.adapter.action({ type: 'button' }, this.callback);
           response = this.adapter.dispatch(this.payload);
           assert(this.callback.notCalled);
-          assert.equal(response.status, 200);
-          return assertResponseContainsMessage(response, '');
+          assert.isUndefined(response);
         });
 
         it('should match when type not present in constraints', function () {
@@ -824,13 +799,12 @@ describe('SlackMessageAdapter', function () {
           this.callback = sinon.spy();
         });
 
-        it('should return a blank success with unfurl is present in constraints and it mismatches', function () {
+        it('should return undefined with unfurl is present in constraints and it mismatches', function () {
           var response;
           this.adapter.action({ unfurl: false }, this.callback);
           response = this.adapter.dispatch(this.payload);
           assert(this.callback.notCalled);
-          assert.equal(response.status, 200);
-          return assertResponseContainsMessage(response, '');
+          assert.isUndefined(response);
         });
 
         it('should match when unfurl not present in constraints', function () {
@@ -847,8 +821,7 @@ describe('SlackMessageAdapter', function () {
         throw new Error('test error');
       });
       response = this.adapter.dispatch({ callback_id: 'a' });
-      assert.equal(response.status, 500);
-      return assertResponseContainsMessage(response, undefined);
+      return assertResponseStatusAndMessage(response, 500);
     });
 
     it('should fail with an error when calling respond inside a callback with a promise', function (done) {

--- a/test/unit/test-express-middleware.js
+++ b/test/unit/test-express-middleware.js
@@ -1,0 +1,143 @@
+var assert = require('chai').assert;
+var sinon = require('sinon');
+var systemUnderTest = require('../../dist/express-middleware');
+var createExpressMiddleware = systemUnderTest.createExpressMiddleware;
+var errorCodes = systemUnderTest.errorCodes;
+
+// fixtures
+var correctVerificationToken = 'VERIFICATION_TOKEN';
+
+function createRequest(payload) {
+  return {
+    body: {
+      payload: JSON.stringify(payload)
+    }
+  };
+}
+
+describe('createExpressMiddleware', function () {
+  beforeEach(function () {
+    this.dispatch = sinon.stub();
+    this.res = sinon.stub({
+      status: function () { },
+      set: function () { },
+      send: function () { },
+      json: function () { },
+      end: function () { }
+    });
+    this.next = sinon.stub();
+    this.middleware = createExpressMiddleware({
+      verificationToken: correctVerificationToken,
+      dispatch: this.dispatch
+    });
+  });
+
+  it('should verify a correct token', function (done) {
+    var dispatch = this.dispatch;
+    var res = this.res;
+    dispatch.resolves({ status: 200 });
+    res.end.callsFake(function () {
+      assert(dispatch.called);
+      assert(res.status.calledWith(200));
+      done();
+    });
+    this.middleware(createRequest({ token: correctVerificationToken }), res, this.next);
+  });
+
+  it('should fail token verification with an incorrect token', function (done) {
+    var res = this.res;
+    this.next.callsFake(function (error) {
+      assert.equal(error.code, errorCodes.TOKEN_VERIFICATION_FAILURE);
+      assert(res.end.notCalled);
+      done();
+    });
+    this.middleware(createRequest({ token: 'INVALID_TOKEN' }), res, this.next);
+  });
+
+  it('should set an identification header in its responses', function (done) {
+    var dispatch = this.dispatch;
+    var res = this.res;
+    dispatch.resolves({ status: 200 });
+    res.end.callsFake(function () {
+      assert(res.set.calledWith('X-Slack-Powered-By'));
+      done();
+    });
+    this.middleware(createRequest({ token: correctVerificationToken }), res, this.next);
+  });
+
+  it('should respond to ssl check requests', function (done) {
+    var dispatch = this.dispatch;
+    var res = this.res;
+    res.end.callsFake(function () {
+      assert(dispatch.notCalled);
+      done();
+    });
+    this.middleware({ body: { ssl_check: 1 } }, res, this.next);
+  });
+
+  describe('handling dispatch results', function () {
+    it('should serialize objects in the content key as JSON', function (done) {
+      var dispatch = this.dispatch;
+      var res = this.res;
+      var content = {
+        abc: 'def',
+        ghi: true,
+        jkl: ['m', 'n', 'o'],
+        p: 5
+      };
+      dispatch.resolves({ status: 200, content: content });
+      res.json.callsFake(function (json) {
+        assert(dispatch.called);
+        assert(res.status.calledWith(200));
+        assert.deepEqual(json, content);
+        done();
+      });
+      this.middleware(createRequest({ token: correctVerificationToken }), res, this.next);
+    });
+
+    it('should handle an undefined content key as no body', function (done) {
+      var dispatch = this.dispatch;
+      var res = this.res;
+      dispatch.resolves({ status: 500 });
+      res.end.callsFake(function () {
+        assert(dispatch.called);
+        assert(res.status.calledWith(500));
+        done();
+      });
+      this.middleware(createRequest({ token: correctVerificationToken }), res, this.next);
+    });
+
+    it('should handle a string content key as the literal body', function (done) {
+      var dispatch = this.dispatch;
+      var res = this.res;
+      var content = 'hello, world';
+      dispatch.resolves({ status: 200, content: content });
+      res.send.callsFake(function (body) {
+        assert(dispatch.called);
+        assert(res.status.calledWith(200));
+        assert.deepEqual(body, content);
+        done();
+      });
+      this.middleware(createRequest({ token: correctVerificationToken }), res, this.next);
+    });
+  });
+
+  // express-specific
+  it('should fail when the request body is not parsed', function (done) {
+    var res = this.res;
+    this.next.callsFake(function (error) {
+      assert.equal(error.code, errorCodes.NO_BODY_PARSER);
+      assert(res.end.notCalled);
+      done();
+    });
+    this.middleware({ notBody: 'someValue' }, res, this.next);
+  });
+
+  it('should forward unmatched dispatches to the next middleware', function () {
+    this.dispatch.returns(undefined);
+    this.middleware(createRequest({ token: correctVerificationToken }), this.res, this.next);
+    assert(this.dispatch.called);
+    assert(this.next.called);
+    assert.equal(this.next.firstCall.args.length, 0);
+  });
+});


### PR DESCRIPTION
###  Summary

Fixes #33 

Lands tests for express-middleware.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing guidelines](https://github.com/slackapi/node-slack-interactive-messages/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
