### PR TITLE
Use the defined `slackVerificationToken` constant

### DIFF
--- a/examples/express-all-interactions/server.js
+++ b/examples/express-all-interactions/server.js
@@ -14,7 +14,7 @@ if (!slackVerificationToken || !slackAccessToken) {
 }
 
 // Create the adapter using the app's verification token
-const slackInteractions = createMessageAdapter(process.env.SLACK_VERIFICATION_TOKEN);
+const slackInteractions = createMessageAdapter(slackVerificationToken);
 
 // Create a Slack Web API client
 const web = new WebClient(slackAccessToken);


### PR DESCRIPTION
###  Summary

The `slackVerificationToken` constant containing the `SLACK_VERIFICATION_TOKEN` environment variable was previously defined a few lines above so let's make use of it: https://github.com/slackapi/node-slack-interactive-messages/blob/a6db6ab476e3e503c4eb9db37e2b4c45eaf6f7c9/examples/express-all-interactions/server.js#L10

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing guidelines](https://github.com/slackapi/node-slack-interactive-messages/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
