### PR TITLE
#64 Fix response Content-Type header.

### DIFF
--- a/src/http-handler.js
+++ b/src/http-handler.js
@@ -28,6 +28,7 @@ export function createHTTPHandler(adapter) {
       if (typeof content === 'string') {
         res.end(content);
       } else if (content) {
+        res.setHeader('Content-Type', 'application/json');
         res.end(JSON.stringify(content));
       } else {
         res.end();


### PR DESCRIPTION
###  Summary

Fix #64 .
Response message should has header `{"Content-Type":"application/json"}`, if it is message object.
Now always message is sent with `{"Content-Type":"text/html"}`, so slack server treat them text message.
Thus, when response message object, show serialized json string in screen.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing guidelines](https://github.com/slackapi/node-slack-interactive-messages/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
