### PR TITLE
adds test to ensure content type is JSON

### DIFF
--- a/test/unit/test-http-handler.js
+++ b/test/unit/test-http-handler.js
@@ -152,6 +152,7 @@ describe('createHTTPHandler', function () {
       res.end.callsFake(function (json) {
         assert(dispatch.called);
         assert.equal(res.statusCode, 200);
+        assert(res.setHeader.calledWith('Content-Type', 'application/json'));
         assert.deepEqual(json, JSON.stringify(content));
         done();
       });


### PR DESCRIPTION
###  Summary

Following up on #65 with a test that can verify its behavior.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing guidelines](https://github.com/slackapi/node-slack-interactive-messages/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
