### PR TITLE
fix body parsing miss symbol

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -206,7 +206,7 @@ export class SlackMessageAdapter {
     const requestListener = this.requestListener();
     return (req, res, next) => {
       // If parser is being used, we can't verify request signature
-      if (req.body) {
+      if (!req.body) {
         const error = new Error('Parsing request body prohibits request signature verification');
         error.code = errorCodes.BODY_PARSER_NOT_PERMITTED;
         next(error);


### PR DESCRIPTION
###  Summary

Express Middleware can't parse body of http request. One symbol was missed.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing guidelines](https://github.com/slackapi/node-slack-interactive-messages/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
