### PR TITLE
Clarify Readme regarding the returning of validation errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,8 @@ slackInteractions.action('create_order_dialog', (payload, respond) => {
   // `payload` is an object that describes the interaction
   console.log(`The user ${payload.user.name} in team ${payload.team.domain} submitted a dialog`);
 
-  // Check the values in `payload.submission` and report any possible errors
+  // Check the values in `payload.submission` and report any possible errors 
+  //   in the format {errors: [{name:'user.name', error:'invalid username'}]}
   const errors = validateOrderSubmission(payload.submission);
   if (errors) {
     return errors;

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ slackInteractions.action('create_order_dialog', (payload, respond) => {
   console.log(`The user ${payload.user.name} in team ${payload.team.domain} submitted a dialog`);
 
   // Check the values in `payload.submission` and report any possible errors 
-  //   in the format {errors: [{name:'user.name', error:'invalid username'}]}
+  //   in the format {errors: [{name:'username', error:'Uh-oh. This username has been taken!'}]}
   const errors = validateOrderSubmission(payload.submission);
   if (errors) {
     return errors;

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ details about the structure of `payload` in the docs for
 
 Unlike with buttons and menus, the response does not replace the message (a dialog is not a message)
 but rather the response tells Slack whether the inputs are valid and the dialog can be closed on
-the user's screen. Your app returns a list of errors (or a Promise for a list of errors) from the
+the user's screen. Your app returns an object with a list of errors as a property (or a Promise for an object with a list of errors as a property) from the
 handler. If there are no errors, your app should return nothing from the handler. Find more details
 on the structure of the list of errors in the docs for
 [input validation](https://api.slack.com/dialogs#input_validation).


### PR DESCRIPTION
###  Summary

For issue #76 to clarify the readme a bit more regarding the returning of validation errors.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing guidelines](https://github.com/slackapi/node-slack-interactive-messages/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
