### PR TITLE
Fix block kit matching logic

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -404,7 +404,6 @@ export class SlackMessageAdapter {
   matchCallback(payload) {
     return this.callbacks.find(([constraints]) => {
       // if the callback ID constraint is specified, only continue if it matches
-      console.log(payload);
       if (constraints.callbackId) {
         if (isString(constraints.callbackId) && payload.callback_id !== constraints.callbackId) {
           return false;

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -404,31 +404,12 @@ export class SlackMessageAdapter {
   matchCallback(payload) {
     return this.callbacks.find(([constraints]) => {
       // if the callback ID constraint is specified, only continue if it matches
+      console.log(payload);
       if (constraints.callbackId) {
         if (isString(constraints.callbackId) && payload.callback_id !== constraints.callbackId) {
           return false;
         }
         if (isRegExp(constraints.callbackId) && !constraints.callbackId.test(payload.callback_id)) {
-          return false;
-        }
-      }
-
-      // if the block ID constraint is specified, only continue if it matches
-      if (constraints.blockId) {
-        if (isString(constraints.blockId) && payload.block_id !== constraints.blockId) {
-          return false;
-        }
-        if (isRegExp(constraints.blockId) && !constraints.blockId.test(payload.block_id)) {
-          return false;
-        }
-      }
-
-      // if the action ID constraint is specified, only continue if it matches
-      if (constraints.actionId) {
-        if (isString(constraints.actionId) && payload.action_id !== constraints.actionId) {
-          return false;
-        }
-        if (isRegExp(constraints.actionId) && !constraints.actionId.test(payload.action_id)) {
           return false;
         }
       }
@@ -443,6 +424,26 @@ export class SlackMessageAdapter {
         // dialog submissions don't have an action defined, so an empty action is substituted for
         // the purpose of callback matching
         const action = payload.actions ? payload.actions[0] : {};
+
+        // if the block ID constraint is specified, only continue if it matches
+        if (constraints.blockId) {
+          if (isString(constraints.blockId) && action.block_id !== constraints.blockId) {
+            return false;
+          }
+          if (isRegExp(constraints.blockId) && !constraints.blockId.test(action.block_id)) {
+            return false;
+          }
+        }
+
+        // if the action ID constraint is specified, only continue if it matches
+        if (constraints.actionId) {
+          if (isString(constraints.actionId) && action.action_id !== constraints.actionId) {
+            return false;
+          }
+          if (isRegExp(constraints.actionId) && !constraints.actionId.test(action.action_id)) {
+            return false;
+          }
+        }
 
         // button and message actions have a type defined inside the action, dialog submission
         // actions have a type defined at the top level, and select actions don't have a type
@@ -473,6 +474,26 @@ export class SlackMessageAdapter {
         // at the top level. in blocks the type is block_suggestion and has no name
         if (!('name' in payload || (payload.type && payload.type === 'block_suggestion'))) {
           return false;
+        }
+
+        // if the block ID constraint is specified, only continue if it matches
+        if (constraints.blockId) {
+          if (isString(constraints.blockId) && payload.block_id !== constraints.blockId) {
+            return false;
+          }
+          if (isRegExp(constraints.blockId) && !constraints.blockId.test(payload.block_id)) {
+            return false;
+          }
+        }
+
+        // if the action ID constraint is specified, only continue if it matches
+        if (constraints.actionId) {
+          if (isString(constraints.actionId) && payload.action_id !== constraints.actionId) {
+            return false;
+          }
+          if (isRegExp(constraints.actionId) && !constraints.actionId.test(payload.action_id)) {
+            return false;
+          }
         }
 
         // an options request always has a type at the top level which can be one of three values

--- a/test/unit/test-adapter.js
+++ b/test/unit/test-adapter.js
@@ -900,7 +900,8 @@ describe('SlackMessageAdapter', function () {
         };
         this.optionsFromBlockMessagePayload = {
           value: 'opti',
-          block_id: 'id',
+          block_id: 'b_id',
+          action_id: 'a_id',
           type: 'block_suggestion'
         };
         this.optionsFromDialogPayload = {
@@ -948,7 +949,7 @@ describe('SlackMessageAdapter', function () {
 
         it('should return undefined with a string mismatch', function () {
           var response;
-          this.adapter.action({ blockId: 'b' }, this.callback);
+          this.adapter.action({ blockId: 'a' }, this.callback);
           response = this.adapter.dispatch(this.payload);
           assert(this.callback.notCalled);
           assert.isUndefined(response);
@@ -956,14 +957,35 @@ describe('SlackMessageAdapter', function () {
 
         it('should return undefined with a RegExp mismatch', function () {
           var response;
-          this.adapter.action({ blockId: /b/ }, this.callback);
+          this.adapter.action({ blockId: /a/ }, this.callback);
           response = this.adapter.dispatch(this.payload);
           assert(this.callback.notCalled);
           assert.isUndefined(response);
         });
 
-        // TODO: successful match on string, successful match on regexp, matches when registered
-        // as an options handler instead
+        it('should match with matching blockId', function () {
+          this.adapter.action({ blockId: 'b_id' }, this.callback);
+          this.adapter.dispatch(this.payload);
+          assert(this.callback.called);
+        });
+
+        it('should match with matching RegExp blockId', function () {
+          this.adapter.action({ blockId: /b/ }, this.callback);
+          this.adapter.dispatch(this.payload);
+          assert(this.callback.called);
+        });
+
+        it('should match with matching blockId with options', function () {
+          this.adapter.options({ blockId: 'b_id' }, this.callback);
+          this.adapter.dispatch(this.optionsFromBlockMessagePayload);
+          assert(this.callback.called);
+        });
+
+        it('should match with matching RegExp blockId with options', function () {
+          this.adapter.options({ blockId: /b/ }, this.callback);
+          this.adapter.dispatch(this.optionsFromBlockMessagePayload);
+          assert(this.callback.called);
+        });
       });
 
       describe('action ID based matching', function () {
@@ -987,8 +1009,29 @@ describe('SlackMessageAdapter', function () {
           assert.isUndefined(response);
         });
 
-        // TODO: successful match on string, successful match on regexp, matches when registered
-        // as an options handler instead
+        it('should match with matching actionId', function () {
+          this.adapter.action({ actionId: 'a_id' }, this.callback);
+          this.adapter.dispatch(this.payload);
+          assert(this.callback.called);
+        });
+
+        it('should match with matching RegExp actionId', function () {
+          this.adapter.action({ actionId: /a/ }, this.callback);
+          this.adapter.dispatch(this.payload);
+          assert(this.callback.called);
+        });
+
+        it('should match with matching string actionId with options', function () {
+          this.adapter.options({ actionId: 'a_id' }, this.callback);
+          this.adapter.dispatch(this.optionsFromBlockMessagePayload);
+          assert(this.callback.called);
+        });
+
+        it('should match with matching RegExp actionId with options', function () {
+          this.adapter.options({ actionId: /a/ }, this.callback);
+          this.adapter.dispatch(this.optionsFromBlockMessagePayload);
+          assert(this.callback.called);
+        });
       });
 
       describe('type based matching', function () {

--- a/test/unit/test-adapter.js
+++ b/test/unit/test-adapter.js
@@ -975,6 +975,22 @@ describe('SlackMessageAdapter', function () {
           assert(this.callback.called);
         });
 
+        it('should return undefined with a string mismatch with options', function () {
+          var response;
+          this.adapter.options({ blockId: 'a' }, this.callback);
+          response = this.adapter.dispatch(this.optionsFromBlockMessagePayload);
+          assert(this.callback.notCalled);
+          assert.isUndefined(response);
+        });
+
+        it('should return undefined with a RegExp mismatch with options', function () {
+          var response;
+          this.adapter.options({ blockId: /a/ }, this.callback);
+          response = this.adapter.dispatch(this.optionsFromBlockMessagePayload);
+          assert(this.callback.notCalled);
+          assert.isUndefined(response);
+        });
+
         it('should match with matching blockId with options', function () {
           this.adapter.options({ blockId: 'b_id' }, this.callback);
           this.adapter.dispatch(this.optionsFromBlockMessagePayload);
@@ -1019,6 +1035,22 @@ describe('SlackMessageAdapter', function () {
           this.adapter.action({ actionId: /a/ }, this.callback);
           this.adapter.dispatch(this.payload);
           assert(this.callback.called);
+        });
+
+        it('should return undefined with a string mismatch with options', function () {
+          var response;
+          this.adapter.options({ actionId: 'b' }, this.callback);
+          response = this.adapter.dispatch(this.optionsFromBlockMessagePayload);
+          assert(this.callback.notCalled);
+          assert.isUndefined(response);
+        });
+
+        it('should return undefined with a RegExp mismatch with options', function () {
+          var response;
+          this.adapter.options({ actionId: /b/ }, this.callback);
+          response = this.adapter.dispatch(this.optionsFromBlockMessagePayload);
+          assert(this.callback.notCalled);
+          assert.isUndefined(response);
         });
 
         it('should match with matching string actionId with options', function () {


### PR DESCRIPTION
###  Summary

The logic for matching `blockId`s and `actionId`s wasn't working because the adapter was looking at the payload's top level rather than in the `actions[]` array. This should fix that and adds tests.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing guidelines](https://github.com/slackapi/node-slack-interactive-messages/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
